### PR TITLE
Fix package installation to include templates and static files

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,7 @@
+include README.md
+include LICENSE
+include CHANGELOG.md
+include CONTRIBUTING.md
+include requirements.txt
+recursive-include src/claude_monitor/web/templates *.html
+recursive-include src/claude_monitor/web/static *

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,3 +25,6 @@ where = ["src"]
 
 [tool.setuptools.package-dir]
 "" = "src"
+
+[tool.setuptools.package-data]
+"claude_monitor.web" = ["templates/**/*.html", "static/**/*"]

--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,13 @@ setup(
     description="Web-based usage monitoring tool for Claude Code",
     packages=find_packages(where="src"),
     package_dir={"": "src"},
+    package_data={
+        "claude_monitor.web": [
+            "templates/**/*.html",
+            "static/**/*",
+        ],
+    },
+    include_package_data=True,
     install_requires=[
         "click>=8.1.0",
         "rich>=13.0.0",


### PR DESCRIPTION
The web application was failing with TemplateNotFound errors when installed via pip because templates and static files were not included in the package distribution.

Changes:
- Add package_data configuration to setup.py to include templates/**/*.html and static/**/* files
- Add include_package_data=True flag to setup.py
- Add [tool.setuptools.package-data] section to pyproject.toml
- Create MANIFEST.in to explicitly include non-Python files in distribution

This fixes the error:
  jinja2.exceptions.TemplateNotFound: pages/dashboard.html

The package now correctly includes all web assets when installed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)