### PR TITLE
Add page spacing and fix repo path handling in routes

### DIFF
--- a/src/claude_monitor/models/__init__.py
+++ b/src/claude_monitor/models/__init__.py
@@ -102,6 +102,7 @@ class Plugin:
     version: str
     description: str
     install_path: Path
+    source: ConfigSource = ConfigSource.PLUGIN
     author: Optional[str] = None
     license: Optional[str] = None
     keywords: List[str] = field(default_factory=list)
@@ -115,6 +116,7 @@ class Plugin:
             'version': self.version,
             'description': self.description,
             'install_path': str(self.install_path),
+            'source': self.source.value,
             'author': self.author,
             'license': self.license,
             'keywords': self.keywords,

--- a/src/claude_monitor/web/routes/dashboard.py
+++ b/src/claude_monitor/web/routes/dashboard.py
@@ -295,6 +295,9 @@ def api_configuration(repo_path: str) -> str:
     """
     try:
         service = current_app.dashboard_service
+        # Flask's path converter strips leading slash, so add it back if missing
+        if not repo_path.startswith('/'):
+            repo_path = '/' + repo_path
         features = service.get_configuration_features(repo_path)
 
         return render_template(
@@ -325,6 +328,9 @@ def api_feature_detail(repo_path: str, feature_type: str, feature_id: str) -> st
     """
     try:
         service = current_app.dashboard_service
+        # Flask's path converter strips leading slash, so add it back if missing
+        if not repo_path.startswith('/'):
+            repo_path = '/' + repo_path
         detail = service.get_feature_detail(repo_path, feature_type, feature_id)
 
         # Render appropriate detail template based on feature type
@@ -366,6 +372,9 @@ def export_configuration(repo_path: str):
 
     try:
         service = current_app.dashboard_service
+        # Flask's path converter strips leading slash, so add it back if missing
+        if not repo_path.startswith('/'):
+            repo_path = '/' + repo_path
         features = service.get_configuration_features(repo_path)
 
         # Find repository name

--- a/src/claude_monitor/web/templates/pages/features.html
+++ b/src/claude_monitor/web/templates/pages/features.html
@@ -83,7 +83,7 @@
 
     <!-- Top Tools Table -->
     {% if features.top_tools %}
-    <div class="bg-white rounded-lg shadow-sm border border-gray-200 overflow-hidden">
+    <div class="bg-white rounded-lg shadow-sm border border-gray-200 overflow-hidden mt-8">
         <div class="px-6 py-4 border-b border-gray-200">
             <h3 class="text-lg font-semibold text-gray-900">Top Tools</h3>
         </div>
@@ -123,7 +123,7 @@
     </div>
     {% else %}
     <!-- No Data Message -->
-    <div class="bg-white rounded-lg shadow-sm border border-gray-200 p-12 text-center">
+    <div class="bg-white rounded-lg shadow-sm border border-gray-200 p-12 text-center mt-8">
         <svg class="mx-auto h-16 w-16 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z"></path><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"></path>
         </svg>

--- a/src/claude_monitor/web/templates/pages/integrations.html
+++ b/src/claude_monitor/web/templates/pages/integrations.html
@@ -89,7 +89,7 @@
 
     <!-- MCP Servers Table -->
     {% if integrations.servers %}
-    <div class="bg-white rounded-lg shadow-sm border border-gray-200 overflow-hidden">
+    <div class="bg-white rounded-lg shadow-sm border border-gray-200 overflow-hidden mt-8">
         <div class="px-6 py-4 border-b border-gray-200">
             <h3 class="text-lg font-semibold text-gray-900">MCP Servers</h3>
         </div>
@@ -129,7 +129,7 @@
     </div>
     {% else %}
     <!-- No Data Message -->
-    <div class="bg-white rounded-lg shadow-sm border border-gray-200 p-12 text-center">
+    <div class="bg-white rounded-lg shadow-sm border border-gray-200 p-12 text-center mt-8">
         <svg class="mx-auto h-16 w-16 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 4a2 2 0 114 0v1a1 1 0 001 1h3a1 1 0 011 1v3a1 1 0 01-1 1h-1a2 2 0 100 4h1a1 1 0 011 1v3a1 1 0 01-1 1h-3a1 1 0 01-1-1v-1a2 2 0 10-4 0v1a1 1 0 01-1 1H7a1 1 0 01-1-1v-3a1 1 0 00-1-1H4a2 2 0 110-4h1a1 1 0 001-1V7a1 1 0 011-1h3a1 1 0 001-1V4z"></path>
         </svg>

--- a/src/claude_monitor/web/templates/pages/tokens.html
+++ b/src/claude_monitor/web/templates/pages/tokens.html
@@ -89,7 +89,7 @@
     </div>
 
     <!-- Token Breakdown by Type -->
-    <div class="bg-white rounded-lg shadow-sm border border-gray-200 overflow-hidden">
+    <div class="bg-white rounded-lg shadow-sm border border-gray-200 overflow-hidden mt-8">
         <div class="px-6 py-4 border-b border-gray-200">
             <h3 class="text-lg font-semibold text-gray-900">Token Breakdown</h3>
         </div>
@@ -146,7 +146,7 @@
     </div>
 
     <!-- Cache Efficiency -->
-    <div class="bg-white rounded-lg shadow-sm border border-gray-200 p-6">
+    <div class="bg-white rounded-lg shadow-sm border border-gray-200 p-6 mt-8">
         <h3 class="text-lg font-semibold text-gray-900 mb-4">Cache Efficiency</h3>
         <div class="grid grid-cols-1 md:grid-cols-3 gap-6">
             <div>

--- a/src/claude_monitor/web/templates/partials/dashboard_content.html
+++ b/src/claude_monitor/web/templates/partials/dashboard_content.html
@@ -28,6 +28,7 @@
 
 <!-- Usage Overview Table -->
 {% from "components/table.html" import responsive_table %}
+<div class="mt-8">
 {% call responsive_table(title="Usage Overview") %}
 <thead class="bg-gray-50">
     <tr>
@@ -58,8 +59,10 @@
     </tr>
 </tbody>
 {% endcall %}
+</div>
 
 <!-- Token Summary Table -->
+<div class="mt-8">
 {% call responsive_table(title="Token Summary") %}
 <thead class="bg-gray-50">
     <tr>
@@ -96,8 +99,10 @@
     </tr>
 </tbody>
 {% endcall %}
+</div>
 
 <!-- Top 5 Projects -->
+<div class="mt-8">
 {% if projects.projects %}
 {% call responsive_table(title="Top 5 Projects") %}
 <thead class="bg-gray-50">
@@ -118,6 +123,7 @@
 </tbody>
 {% endcall %}
 {% endif %}
+</div>
 
 <!-- Charts Section -->
 <div class="grid grid-cols-1 lg:grid-cols-2 gap-6 mt-8">

--- a/src/claude_monitor/web/templates/partials/features_content.html
+++ b/src/claude_monitor/web/templates/partials/features_content.html
@@ -23,7 +23,7 @@
 
 <!-- Tool Usage Breakdown -->
 {% if features.tool_usage %}
-<div class="grid grid-cols-1 lg:grid-cols-2 gap-8">
+<div class="grid grid-cols-1 lg:grid-cols-2 gap-8 mt-8">
     <!-- Most Used Tools -->
     <div class="bg-white rounded-lg shadow-sm border border-gray-200 p-6">
         <h3 class="text-lg font-semibold text-gray-900 mb-4">Most Used Tools</h3>
@@ -77,7 +77,7 @@
     </div>
 </div>
 {% else %}
-<div class="bg-white rounded-lg shadow-sm border border-gray-200 overflow-hidden">
+<div class="bg-white rounded-lg shadow-sm border border-gray-200 overflow-hidden mt-8">
     <div class="px-6 py-12 text-center">
         <svg class="mx-auto h-12 w-12 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z"></path>

--- a/src/claude_monitor/web/templates/partials/files_content.html
+++ b/src/claude_monitor/web/templates/partials/files_content.html
@@ -29,7 +29,7 @@
 
 <!-- File Operations Table -->
 {% if files.file_operations %}
-<div class="bg-white rounded-lg shadow-sm border border-gray-200 overflow-hidden">
+<div class="bg-white rounded-lg shadow-sm border border-gray-200 overflow-hidden mt-8">
     <div class="px-6 py-4 border-b border-gray-200">
         <h3 class="text-lg font-semibold text-gray-900">Recent File Operations</h3>
     </div>
@@ -93,7 +93,7 @@
     </div>
 </div>
 {% else %}
-<div class="bg-white rounded-lg shadow-sm border border-gray-200 overflow-hidden">
+<div class="bg-white rounded-lg shadow-sm border border-gray-200 overflow-hidden mt-8">
     <div class="px-6 py-12 text-center">
         <svg class="mx-auto h-12 w-12 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20 13V6a2 2 0 00-2-2H6a2 2 0 00-2 2v7m16 0v5a2 2 0 01-2 2H6a2 2 0 01-2-2v-5m16 0h-2.586a1 1 0 00-.707.293l-2.414 2.414a1 1 0 01-.707.293h-3.172a1 1 0 01-.707-.293l-2.414-2.414A1 1 0 006.586 13H4"></path>

--- a/src/claude_monitor/web/templates/partials/integrations_content.html
+++ b/src/claude_monitor/web/templates/partials/integrations_content.html
@@ -29,7 +29,7 @@
 
 <!-- MCP Servers Activity -->
 {% if integrations.server_activity %}
-<div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
+<div class="grid grid-cols-1 lg:grid-cols-2 gap-6 mt-8">
     {% for server in integrations.server_activity %}
     <div class="bg-white rounded-lg shadow-sm border border-gray-200 p-6">
         <div class="flex items-center justify-between mb-4">
@@ -68,7 +68,7 @@
     {% endfor %}
 </div>
 {% else %}
-<div class="bg-white rounded-lg shadow-sm border border-gray-200 overflow-hidden">
+<div class="bg-white rounded-lg shadow-sm border border-gray-200 overflow-hidden mt-8">
     <div class="px-6 py-12 text-center">
         <svg class="mx-auto h-12 w-12 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 12h14M5 12a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v4a2 2 0 01-2 2M5 12a2 2 0 00-2 2v4a2 2 0 002 2h14a2 2 0 002-2v-4a2 2 0 00-2-2m-2-4h.01M17 16h.01"></path>

--- a/src/claude_monitor/web/templates/partials/projects_content.html
+++ b/src/claude_monitor/web/templates/partials/projects_content.html
@@ -22,7 +22,7 @@
 </div>
 
 <!-- Projects Table -->
-<div class="bg-white rounded-lg shadow-sm border border-gray-200 overflow-hidden">
+<div class="bg-white rounded-lg shadow-sm border border-gray-200 overflow-hidden mt-8">
     <div class="px-6 py-4 border-b border-gray-200">
         <h3 class="text-lg font-semibold text-gray-900">All Projects</h3>
     </div>

--- a/src/claude_monitor/web/templates/partials/tokens_content.html
+++ b/src/claude_monitor/web/templates/partials/tokens_content.html
@@ -28,7 +28,7 @@
 </div>
 
 <!-- Cost Breakdown -->
-<div class="grid grid-cols-1 lg:grid-cols-2 gap-8">
+<div class="grid grid-cols-1 lg:grid-cols-2 gap-8 mt-8">
     <div class="bg-white rounded-lg shadow-sm border border-gray-200 p-6">
         <h3 class="text-lg font-semibold text-gray-900 mb-4">Cost Breakdown</h3>
         <div class="space-y-4">


### PR DESCRIPTION
## Summary
- Add consistent `mt-8` spacing between sections on all dashboard pages for better visual hierarchy
- Fix Flask path converter stripping leading slash from `repo_path` parameter in API routes
- Add `source` field to Plugin dataclass for tracking configuration origin

## Test plan
- [ ] Verify spacing looks correct on all 6 dashboard pages
- [ ] Test features page loads correctly for repositories with absolute paths
- [ ] Test configuration export works for all repositories

🤖 Generated with [Claude Code](https://claude.com/claude-code)