### PR TITLE
Potential fix for code scanning alert no. 11: Log Injection

### DIFF
--- a/src/claude_monitor/web/routes/dashboard.py
+++ b/src/claude_monitor/web/routes/dashboard.py
@@ -384,7 +384,9 @@ def api_feature_detail(repo_path: str, feature_type: str, feature_id: str) -> st
         )
 
     except Exception as e:
-        logger.error(f'Error loading detail for {feature_type} {feature_id}: {e}', exc_info=True)
+        safe_feature_type = feature_type.replace('\r', '').replace('\n', '')
+        safe_feature_id = feature_id.replace('\r', '').replace('\n', '')
+        logger.error(f'Error loading detail for {safe_feature_type} {safe_feature_id}: {e}', exc_info=True)
         return f'<div class="alert alert-error">Error loading feature details: {str(e)}</div>'
 
 


### PR DESCRIPTION
Potential fix for [https://github.com/allannapier/claude_monitor/security/code-scanning/11](https://github.com/allannapier/claude_monitor/security/code-scanning/11)

In general, to fix log injection you should avoid writing raw user input directly into log message text. Either (1) sanitize user input to remove control characters like `\r` and `\n` before logging, or (2) use structured logging with arguments so the logger, not string concatenation, handles formatting. For plain-text logs, stripping or replacing newline and carriage‑return characters is typically sufficient.

For this specific case in `src/claude_monitor/web/routes/dashboard.py`, the best minimal fix is to sanitize `feature_type` and `feature_id` just before logging in the `except` block of `api_feature_detail`. We can introduce small helper function(s) or inline sanitization to remove `\r` and `\n` from those variables, then use the sanitized versions in the log message. This preserves existing functionality and log content while preventing an attacker from injecting extra lines. No changes are needed to the route definition or overall flow.

Concretely:
- In `api_feature_detail`, inside the `except Exception as e:` block (around lines 386–388), create sanitized versions of `feature_type` and `feature_id`, e.g. `safe_feature_type = feature_type.replace('\r', '').replace('\n', '')` and same for `feature_id`.
- Use these `safe_...` variables in the `logger.error` call instead of the raw route parameters.
- Keep the rendered HTML response unchanged, since the CodeQL alert concerns the log sink, not the HTTP output.

No new imports are necessary; we only use built‑in string methods.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
