### PR TITLE
Potential fix for code scanning alert no. 10: Log Injection

### DIFF
--- a/src/claude_monitor/web/routes/dashboard.py
+++ b/src/claude_monitor/web/routes/dashboard.py
@@ -340,7 +340,9 @@ def api_configuration(repo_path: str) -> str:
     except Exception as e:
         # Sanitize user-provided repo_path to prevent log injection
         safe_repo_path = repo_path.replace('\r', '').replace('\n', '')
-        logger.error(f'Error loading configuration for repo {safe_repo_path}: {e}', exc_info=True)
+        # Sanitize exception message to prevent log injection via newline characters
+        safe_error = str(e).replace('\r', '').replace('\n', '')
+        logger.error(f'Error loading configuration for repo {safe_repo_path}: {safe_error}', exc_info=True)
         return render_template(
             'partials/feature_list.html',
             features={}


### PR DESCRIPTION
Potential fix for [https://github.com/allannapier/claude_monitor/security/code-scanning/10](https://github.com/allannapier/claude_monitor/security/code-scanning/10)

In general, to fix log injection where user input is logged, sanitize the user-controlled value before inserting it into the log message. For plain-text logs, a simple and effective measure is to strip or replace newline (`\n`) and carriage return (`\r`) characters and optionally other control characters. This preserves the content while preventing an attacker from breaking the log line or injecting fake entries.

For this specific issue, the best minimal fix is to sanitize `repo_path` inside the `except` block before using it in the `logger.error` call. We can create a local variable (e.g., `safe_repo_path`) derived from `repo_path` with `\r` and `\n` removed (or replaced with a safe placeholder) and then log `safe_repo_path` instead of the raw `repo_path`. This keeps existing behavior and message structure while preventing multi-line log injection. All changes are confined to `src/claude_monitor/web/routes/dashboard.py` in the `api_configuration` function’s exception handler; no new imports are needed and existing functionality remains unchanged.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
