### PR TITLE
Potential fix for code scanning alert no. 9: Information exposure through an exception

### DIFF
--- a/src/claude_monitor/web/routes/dashboard.py
+++ b/src/claude_monitor/web/routes/dashboard.py
@@ -821,4 +821,4 @@ def export_data(format: str) -> Any:
     
     except Exception as e:
         logger.error(f'Error exporting data: {e}', exc_info=True)
-        return f'Error exporting data: {str(e)}', 500
+        return 'Error exporting data. Please check the server logs for more details.', 500


### PR DESCRIPTION
Potential fix for [https://github.com/allannapier/claude_monitor/security/code-scanning/9](https://github.com/allannapier/claude_monitor/security/code-scanning/9)

In general, the fix is to avoid returning the raw exception message (`str(e)`) in the HTTP response body. Instead, we should (1) keep logging the full error and stack trace on the server for debugging, and (2) return a generic, non-sensitive error message to the client. This preserves observability for developers while preventing information disclosure to users.

For this specific case in `src/claude_monitor/web/routes/dashboard.py`, we should modify the `except Exception as e:` block in `export_data` so that:
- We keep the existing `logger.error(..., exc_info=True)` line unchanged, so stack trace information is still recorded in logs.
- We change the returned value from `f'Error exporting data: {str(e)}', 500` to a generic message like `'Error exporting data. Please check server logs for details.', 500`. This mirrors the pattern used by the other handlers in the file that do not reveal exception internals.

No new imports or helper methods are required, and this change does not alter the functionality of successful export flows; it only adjusts the error response content.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
