### PR TITLE
feat: Enable remote access by default with 0.0.0.0 binding

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ pip install .
 ### Running
 
 ```bash
-# Start the web server (default port 5000)
+# Start the web server (default port 5000, accessible from all network interfaces)
 claudesavvy
 
 # Open your browser to http://localhost:5000
@@ -82,14 +82,14 @@ That's it! The dashboard will load your Claude Code usage data automatically.
 ### Basic Commands
 
 ```bash
-# Start server on default port 5000
+# Start server on default port 5000 (accessible from all network interfaces)
 claudesavvy
 
 # Start on custom port
 claudesavvy --port 8080
 
-# Bind to all network interfaces (allow external access)
-claudesavvy --host 0.0.0.0
+# Bind to localhost only (for enhanced security)
+claudesavvy --host 127.0.0.1
 
 # Enable debug mode with auto-reload
 claudesavvy --debug

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -29,7 +29,7 @@ Claude Monitor reads the following local files:
 - `~/.claude/skills/` - Installed skills
 - `~/.claude/settings.json` - Claude Code settings
 
-**All data stays on your machine.** The web server runs locally and only listens on localhost by default (127.0.0.1).
+**All data stays on your machine.** The web server runs locally and by default listens on all network interfaces (0.0.0.0). For enhanced security, you can bind to localhost only using `--host 127.0.0.1`.
 
 ## Reporting a Vulnerability
 
@@ -72,9 +72,10 @@ When using Claude Monitor:
 
 ### For Users
 
-1. **Localhost Only**: By default, the server binds to 127.0.0.1 (localhost only)
-   - Only expose to network (`--host 0.0.0.0`) if you understand the risks
+1. **Network Access**: By default, the server binds to all network interfaces (0.0.0.0)
+   - For enhanced security, bind to localhost only: `--host 127.0.0.1`
    - Never expose to the public internet without proper authentication
+   - Use a firewall to restrict access when running on a network
 
 2. **Keep Updated**: Use the latest version to get security fixes
    ```bash

--- a/src/claudesavvy/cli.py
+++ b/src/claudesavvy/cli.py
@@ -18,8 +18,8 @@ from .utils.paths import get_claude_paths, ClaudeDataPaths
 @click.option(
     '--host',
     type=str,
-    default='127.0.0.1',
-    help='Host to bind to (default: 127.0.0.1)'
+    default='0.0.0.0',
+    help='Host to bind to (default: 0.0.0.0)'
 )
 @click.option(
     '--debug',
@@ -43,14 +43,14 @@ def main(port, host, debug, claude_dir):
 
     Examples:
 
-      # Start server on default port 5000
+      # Start server on default port 5000 (accessible from all network interfaces)
       $ claudesavvy
 
       # Start on custom port
       $ claudesavvy --port 8080
 
-      # Bind to all network interfaces (allow external access)
-      $ claudesavvy --host 0.0.0.0
+      # Bind to localhost only (for enhanced security)
+      $ claudesavvy --host 127.0.0.1
 
       # Enable debug mode with auto-reload
       $ claudesavvy --debug


### PR DESCRIPTION
## Summary
- Changed default server host binding from `127.0.0.1` to `0.0.0.0` to enable remote network access by default
- Users can still bind to localhost-only using `--host 127.0.0.1` for enhanced security
- Updated all documentation to reflect the new default behavior

## Motivation
Previously, the server only listened on localhost (127.0.0.1), making it inaccessible from other devices on the network. This change makes the dashboard available from remote machines, which is useful for:
- Accessing the dashboard from a different computer
- Viewing metrics on a mobile device or tablet
- Sharing metrics with team members on the same network

## Changes
- **CLI**: Updated default host from `127.0.0.1` to `0.0.0.0`
- **Documentation**: Reversed examples to show localhost-only as an optional security measure
- **Security Guide**: Updated SECURITY.md with network access guidance and firewall recommendations

## Security Considerations
- The server now binds to all network interfaces by default
- Users who want enhanced security can use `--host 127.0.0.1` to restrict access to localhost only
- Added firewall recommendations in SECURITY.md
- Documentation clearly explains the security implications

## Test plan
- [x] Verify server starts with default 0.0.0.0 binding
- [x] Test `--host 127.0.0.1` option for localhost-only mode
- [x] Verify `--host` and `--port` options work together correctly
- [x] Review documentation updates for clarity

🤖 Generated with [Claude Code](https://claude.com/claude-code)