### PR TITLE
fix: Address security and code review feedback

### DIFF
--- a/src/claudesavvy/cli.py
+++ b/src/claudesavvy/cli.py
@@ -18,8 +18,8 @@ from .utils.paths import get_claude_paths, ClaudeDataPaths
 @click.option(
     '--host',
     type=str,
-    default='0.0.0.0',
-    help='Host to bind to (default: 0.0.0.0)'
+    default='127.0.0.1',
+    help='Host to bind to (default: 127.0.0.1)'
 )
 @click.option(
     '--debug',
@@ -43,14 +43,14 @@ def main(port, host, debug, claude_dir):
 
     Examples:
 
-      # Start server on default port 5000 (accessible from all network interfaces)
+      # Start server on default port 5000 (localhost-only, secure)
       $ claudesavvy
 
       # Start on custom port
       $ claudesavvy --port 8080
 
-      # Bind to localhost only (for enhanced security)
-      $ claudesavvy --host 127.0.0.1
+      # Make accessible from network (use with caution)
+      $ claudesavvy --host 0.0.0.0
 
       # Enable debug mode with auto-reload
       $ claudesavvy --debug

--- a/src/claudesavvy/web/routes/dashboard.py
+++ b/src/claudesavvy/web/routes/dashboard.py
@@ -929,7 +929,7 @@ def api_pricing_settings() -> Any:
 
     except Exception as e:
         logger.error(f'Error getting pricing settings: {e}', exc_info=True)
-        return jsonify({'error': str(e)}), 500
+        return jsonify({'error': 'Failed to retrieve pricing settings'}), 500
 
 
 @dashboard_bp.route('/api/settings/pricing/update', methods=['POST'])
@@ -971,11 +971,11 @@ def api_update_pricing() -> Any:
 
         return jsonify(result), 200 if result['success'] else 500
 
-    except ValueError as e:
-        return jsonify({'success': False, 'error': f'Invalid value: {str(e)}'}), 400
+    except ValueError:
+        return jsonify({'success': False, 'error': 'Invalid value provided'}), 400
     except Exception as e:
         logger.error(f'Error updating pricing: {e}', exc_info=True)
-        return jsonify({'success': False, 'error': str(e)}), 500
+        return jsonify({'success': False, 'error': 'Failed to update pricing'}), 500
 
 
 @dashboard_bp.route('/api/settings/pricing/reset', methods=['POST'])
@@ -1005,4 +1005,4 @@ def api_reset_pricing() -> Any:
 
     except Exception as e:
         logger.error(f'Error resetting pricing: {e}', exc_info=True)
-        return jsonify({'success': False, 'error': str(e)}), 500
+        return jsonify({'success': False, 'error': 'Failed to reset pricing'}), 500

--- a/src/claudesavvy/web/templates/pages/settings.html
+++ b/src/claudesavvy/web/templates/pages/settings.html
@@ -1,7 +1,7 @@
 {% extends "layouts/app.html" %}
 {% from "components/card.html" import stat_card %}
 
-{% block title %}Settings - Claude Monitor{% endblock %}
+{% block title %}Settings - LLM Monitor{% endblock %}
 
 {% block main_content %}
 <div class="space-y-8" x-data="settingsApp()">


### PR DESCRIPTION
## Summary

This PR addresses feedback from the code review on the custom model pricing feature, including security improvements and bug fixes.

## Changes

### Security Fixes
- **Reverted default host binding**: Changed from `0.0.0.0` back to `127.0.0.1` for security by default
  - Users who need network access can explicitly use `--host 0.0.0.0`
  - Updated CLI examples to reflect this security-first approach

- **Fixed exception exposure**: API endpoints no longer expose stack traces to users
  - Replaced `str(e)` with generic error messages
  - Full details still logged to server logs for debugging

### Bug Fixes
- **Fixed cyclic import**: Removed import cycle between `pricing.py` and `tokens.py`
  - `DEFAULT_PRICING` now defined in `pricing.py` to avoid circular dependency
  
- **Fixed empty dictionary issue**: Settings page now shows models with custom pricing even when no session data exists
  - `get_all_pricing()` now always includes models with custom pricing configured
  - Additional models from session data are added when available

- **Fixed page title**: Changed from "Settings - Claude Monitor" to "Settings - LLM Monitor" for consistency with the generic, model-agnostic approach

## Test Plan
- [ ] Verify settings page loads correctly
- [ ] Test with no session data (should show custom pricing models if configured)
- [ ] Verify API error responses are generic (no stack traces)
- [ ] Confirm default host is `127.0.0.1` (security)
- [ ] Test that `--host 0.0.0.0` still works for users who need it

🤖 Generated with [Claude Code](https://claude.com/claude-code)