### PR TITLE
Potential fix for code scanning alert no. 55: Information exposure through an exception

### DIFF
--- a/src/claudesavvy/web/routes/dashboard.py
+++ b/src/claudesavvy/web/routes/dashboard.py
@@ -733,7 +733,7 @@ def api_features() -> str:
 
     except Exception as e:
         logger.error(f'Error loading filtered features: {e}', exc_info=True)
-        return f'<div class="text-red-600 p-4">Error loading features: {str(e)}</div>', 500
+        return '<div class="text-red-600 p-4">Error loading features. Please try again later.</div>', 500
 
 
 @dashboard_bp.route('/api/project/analyze')


### PR DESCRIPTION
Potential fix for [https://github.com/allannapier/claudesavvy/security/code-scanning/55](https://github.com/allannapier/claudesavvy/security/code-scanning/55)

In general, to fix this type of problem you should avoid returning raw exception details to the client. Instead, log the full exception server-side (including stack trace) and return a generic, user-friendly error message that does not reveal internal details. This preserves debuggability while preventing attackers from learning about your internals.

Concretely for `src/claudesavvy/web/routes/dashboard.py`, only the `except Exception as e` block in `api_features` needs to change. The logging call at line 735 is already appropriate (`exc_info=True` records the stack trace). The vulnerable part is line 736, which returns an HTML string containing `str(e)`. We should replace this with a generic message like “Error loading features. Please try again later.” and remove the interpolation of `e`. No new imports or helpers are necessary; we only change the returned string.

Precise changes:

- In `api_features` (around lines 734–736), keep the `logger.error(...)` call as-is.
- Replace the line:
  - `return f'<div class="text-red-600 p-4">Error loading features: {str(e)}</div>', 500`
- With a safe, generic message not containing `e`, e.g.:
  - `return '<div class="text-red-600 p-4">Error loading features. Please try again later.</div>', 500`

No other routes or files need changes for this specific CodeQL finding.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
