### PR TITLE
feat: share time period across all main analytics pages

### DIFF
--- a/src/claudesavvy/web/templates/pages/conversations.html
+++ b/src/claudesavvy/web/templates/pages/conversations.html
@@ -13,7 +13,7 @@
         </div>
 
         {% set _conv_period = 'today' if period in ('week', 'month', '1hour') else period|default('today') %}
-        {% with current_url='/api/conversations', target_id='conversations-content', show_realtime=true, storage_key='cs_period_conversations', default_period=_conv_period %}
+        {% with current_url='/api/conversations', target_id='conversations-content', show_realtime=true, storage_key='cs_period', default_period=_conv_period %}
             {% include 'partials/time_filter.html' %}
         {% endwith %}
     </div>

--- a/src/claudesavvy/web/templates/pages/dashboard.html
+++ b/src/claudesavvy/web/templates/pages/dashboard.html
@@ -12,7 +12,7 @@
         </div>
 
         <div class="flex gap-2 items-center shrink-0">
-            {% with current_url='/api/dashboard', target_id='dashboard-content', storage_key='cs_period_dashboard', default_period=period|default('today') %}
+            {% with current_url='/api/dashboard', target_id='dashboard-content', storage_key='cs_period', default_period=period|default('today') %}
                 {% include 'partials/time_filter.html' %}
             {% endwith %}
 

--- a/src/claudesavvy/web/templates/pages/features.html
+++ b/src/claudesavvy/web/templates/pages/features.html
@@ -12,7 +12,7 @@
             <p class="mt-2 text-gray-600">Tool usage analytics and statistics</p>
         </div>
 
-        {% with current_url='/api/features', target_id='features-content', show_realtime=true, storage_key='cs_period_features', default_period=period|default('today') %}
+        {% with current_url='/api/features', target_id='features-content', show_realtime=true, storage_key='cs_period', default_period=period|default('today') %}
             {% include 'partials/time_filter.html' %}
         {% endwith %}
     </div>

--- a/src/claudesavvy/web/templates/pages/files.html
+++ b/src/claudesavvy/web/templates/pages/files.html
@@ -12,7 +12,7 @@
             <p class="mt-2 text-gray-600">File-level usage statistics and analytics</p>
         </div>
 
-        {% with current_url='/api/files', target_id='files-content', show_realtime=true, storage_key='cs_period_files', default_period=period|default('today') %}
+        {% with current_url='/api/files', target_id='files-content', show_realtime=true, storage_key='cs_period', default_period=period|default('today') %}
             {% include 'partials/time_filter.html' %}
         {% endwith %}
     </div>

--- a/src/claudesavvy/web/templates/pages/integrations.html
+++ b/src/claudesavvy/web/templates/pages/integrations.html
@@ -12,7 +12,7 @@
             <p class="mt-2 text-gray-600">MCP servers and tool integration statistics</p>
         </div>
 
-        {% with current_url='/api/integrations', target_id='integrations-content', storage_key='cs_period_integrations', default_period=period|default('today') %}
+        {% with current_url='/api/integrations', target_id='integrations-content', storage_key='cs_period', default_period=period|default('today') %}
             {% include 'partials/time_filter.html' %}
         {% endwith %}
     </div>

--- a/src/claudesavvy/web/templates/pages/projects.html
+++ b/src/claudesavvy/web/templates/pages/projects.html
@@ -14,14 +14,14 @@
         window.selectedPeriod = this.selectedPeriod;
         this.$watch('selectedPeriod', v => window.selectedPeriod = v);
         const legacyMap = { week: '7days', month: 'this_month', '1hour': '15min' };
-        const raw = localStorage.getItem('cs_period_projects');
+        const raw = localStorage.getItem('cs_period');
         const stored = raw && legacyMap[raw] ? legacyMap[raw] : raw;
         const validPeriods = ['15min','today','this_week','7days','this_month','3months','all','custom'];
         if (stored && validPeriods.includes(stored)) {
             this.selectedPeriod = stored;
             if (stored === 'custom') {
-                this.customStart = localStorage.getItem('cs_period_projects_start') || '';
-                this.customEnd   = localStorage.getItem('cs_period_projects_end')   || '';
+                this.customStart = localStorage.getItem('cs_period_start') || '';
+                this.customEnd   = localStorage.getItem('cs_period_end')   || '';
                 if (this.customStart && this.customEnd) {
                     this.showCustom = true;
                 } else {
@@ -47,13 +47,13 @@
     select(period) {
         this.selectedPeriod = period;
         this.showCustom = (period === 'custom');
-        localStorage.setItem('cs_period_projects', period);
+        localStorage.setItem('cs_period', period);
         if (period !== 'custom') { this._reload(period); }
     },
     applyCustom() {
         if (!this.customStart || !this.customEnd) return;
-        localStorage.setItem('cs_period_projects_start', this.customStart);
-        localStorage.setItem('cs_period_projects_end',   this.customEnd);
+        localStorage.setItem('cs_period_start', this.customStart);
+        localStorage.setItem('cs_period_end',   this.customEnd);
         this._reload('custom');
     }
 }">

--- a/src/claudesavvy/web/templates/pages/subagents.html
+++ b/src/claudesavvy/web/templates/pages/subagents.html
@@ -12,7 +12,7 @@
             <p class="mt-2 text-gray-600">Token exchange analytics for Task tool sub-agent invocations</p>
         </div>
 
-        {% with current_url='/api/subagents', target_id='subagents-content', show_realtime=true, storage_key='cs_period_subagents', default_period=period|default('today') %}
+        {% with current_url='/api/subagents', target_id='subagents-content', show_realtime=true, storage_key='cs_period', default_period=period|default('today') %}
             {% include 'partials/time_filter.html' %}
         {% endwith %}
     </div>

--- a/src/claudesavvy/web/templates/pages/tokens.html
+++ b/src/claudesavvy/web/templates/pages/tokens.html
@@ -13,14 +13,14 @@
     customEnd: '',
     init() {
         const legacyMap = { week: '7days', month: 'this_month', '1hour': '15min' };
-        const raw = localStorage.getItem('cs_period_tokens');
+        const raw = localStorage.getItem('cs_period');
         const stored = raw && legacyMap[raw] ? legacyMap[raw] : raw;
         const validPeriods = ['15min','today','this_week','7days','this_month','3months','all','custom'];
         if (stored && validPeriods.includes(stored)) {
             this.selectedPeriod = stored;
             if (stored === 'custom') {
-                this.customStart = localStorage.getItem('cs_period_tokens_start') || '';
-                this.customEnd   = localStorage.getItem('cs_period_tokens_end')   || '';
+                this.customStart = localStorage.getItem('cs_period_start') || '';
+                this.customEnd   = localStorage.getItem('cs_period_end')   || '';
                 if (this.customStart && this.customEnd) {
                     this.showCustom = true;
                 } else {
@@ -46,13 +46,13 @@
     select(period) {
         this.selectedPeriod = period;
         this.showCustom = (period === 'custom');
-        localStorage.setItem('cs_period_tokens', period);
+        localStorage.setItem('cs_period', period);
         if (period !== 'custom') { this._reload(period); }
     },
     applyCustom() {
         if (!this.customStart || !this.customEnd) return;
-        localStorage.setItem('cs_period_tokens_start', this.customStart);
-        localStorage.setItem('cs_period_tokens_end',   this.customEnd);
+        localStorage.setItem('cs_period_start', this.customStart);
+        localStorage.setItem('cs_period_end',   this.customEnd);
         this._reload('custom');
     }
 }">


### PR DESCRIPTION
All main analytics pages (dashboard, conversations, tokens, projects, features, files, integrations, subagents) now read/write a single shared localStorage key `cs_period` (+ `cs_period_start`/`cs_period_end` for custom ranges).

Changing the period on any page propagates to every other page on next load — no more re-selecting "Last 7 days" eight times.

Harness (`harness_eval_period`, default 7days) and Teams (`cs_period_teams`, default all) keep their own keys since they have different default windows and different data semantics.

https://claude.ai/code/session_01NZ73dcgFQr3UMMRLKUCegZ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes & Improvements**
  * Unified time period filter persistence across all pages, enabling consistent date selection behavior throughout the application.
  * Updated custom date range handling on Projects and Tokens pages for improved state management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->