### PR TITLE
feat: harness quality section first + auto-load worst session

### DIFF
--- a/src/claudesavvy/web/templates/pages/harness.html
+++ b/src/claudesavvy/web/templates/pages/harness.html
@@ -29,6 +29,24 @@
         </div>
     </div>
 
+    <!-- Session Quality Evaluation (most actionable — first) -->
+    <div class="space-y-4">
+        <div class="flex flex-wrap items-center gap-3">
+            <div>
+                <h2 class="text-lg font-semibold text-gray-900">Session quality</h2>
+                <p class="text-sm text-gray-500">How efficiently the harness ran your sessions — ranked by dollars wasted so you know what to tune first.</p>
+            </div>
+            <div class="ml-auto">
+                {% with current_url='/api/harness/evaluation', target_id='harness-eval-content', default_period='7days', storage_key='harness_eval_period', filter_projects=harness_projects %}
+                {% include "partials/time_filter.html" %}
+                {% endwith %}
+            </div>
+        </div>
+        <div id="harness-eval-content">
+            {% include "partials/harness_evaluation.html" %}
+        </div>
+    </div>
+
     <!-- Summary KPI Row -->
     <div class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-6 gap-4">
         {% set counts = [
@@ -50,24 +68,6 @@
             <div class="text-2xl font-bold text-gray-900">{{ count }}</div>
         </div>
         {% endfor %}
-    </div>
-
-    <!-- Session Quality Evaluation -->
-    <div class="space-y-4">
-        <div class="flex flex-wrap items-center gap-3">
-            <div>
-                <h2 class="text-lg font-semibold text-gray-900">Session quality</h2>
-                <p class="text-sm text-gray-500">How efficiently the harness ran your sessions — scored worst-first so you know what to tune.</p>
-            </div>
-            <div class="ml-auto">
-                {% with current_url='/api/harness/evaluation', target_id='harness-eval-content', default_period='7days', storage_key='harness_eval_period', filter_projects=harness_projects %}
-                {% include "partials/time_filter.html" %}
-                {% endwith %}
-            </div>
-        </div>
-        <div id="harness-eval-content">
-            {% include "partials/harness_evaluation.html" %}
-        </div>
     </div>
 
     <!-- Scope Level Tabs -->

--- a/src/claudesavvy/web/templates/partials/harness_evaluation.html
+++ b/src/claudesavvy/web/templates/partials/harness_evaluation.html
@@ -111,8 +111,10 @@
         </div>
     </div>
 
-    <!-- Leaderboard (worst-first) + detail panel -->
-    <div class="grid grid-cols-1 lg:grid-cols-2 gap-5">
+    <!-- Leaderboard (most $ wasted first) + detail panel -->
+    {% set first_id = evaluation.sessions[0].session_id if evaluation.sessions else '' %}
+    <div class="grid grid-cols-1 lg:grid-cols-2 gap-5"
+         x-data="{ sel: '{{ first_id }}' }">
         <div class="bg-white rounded-xl border border-gray-200 overflow-hidden">
             <div class="flex items-center gap-2 px-4 py-3 border-b border-gray-100">
                 <span class="text-sm font-semibold text-gray-800">Sessions worth fixing</span>
@@ -126,7 +128,10 @@
                             hx-get="/api/harness/session/{{ s.session_id }}"
                             hx-target="#harness-session-panel"
                             hx-swap="innerHTML"
-                            class="w-full text-left px-4 py-3 flex items-center gap-3 hover:bg-gray-50 transition-colors focus:outline-none focus:bg-blue-50">
+                            {% if loop.first %}hx-trigger="load, click"{% endif %}
+                            @click="sel = '{{ s.session_id }}'"
+                            class="w-full text-left px-4 py-3 flex items-center gap-3 transition-colors focus:outline-none"
+                            :class="sel === '{{ s.session_id }}' ? 'bg-blue-50 ring-1 ring-inset ring-[#0770E3]/20' : 'hover:bg-gray-50'">
                         <span class="w-9 h-9 rounded-lg flex items-center justify-center text-sm font-bold shrink-0"
                               style="background: {{ gc }}18; color: {{ gc }};">{{ s.grade }}</span>
                         <div class="min-w-0 flex-1">
@@ -154,13 +159,13 @@
             </ul>
         </div>
 
-        <!-- Detail panel -->
-        <div id="harness-session-panel" class="bg-white rounded-xl border border-gray-200 p-6 flex items-center justify-center text-center">
-            <div class="text-gray-400">
-                <svg class="w-8 h-8 mx-auto mb-2" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="1.4">
-                    <path d="M9 5l7 7-7 7"/>
+        <!-- Detail panel — pre-populated via auto-fired first-row load -->
+        <div id="harness-session-panel" class="bg-white rounded-xl border border-gray-200 overflow-auto">
+            <div class="p-8 flex items-center justify-center text-gray-400">
+                <svg class="w-5 h-5 animate-spin" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                    <circle cx="12" cy="12" r="10" stroke-opacity="0.25"/>
+                    <path d="M12 2a10 10 0 0 1 10 10" stroke-linecap="round"/>
                 </svg>
-                <p class="text-sm">Select a session to see its score breakdown and tuning suggestions.</p>
             </div>
         </div>
     </div>


### PR DESCRIPTION
Reorders the harness page so the quality/scoring section appears above the KPI inventory counts — it's the most actionable view and should be above the fold.

Auto-loads the worst (most $ wasted) session into the detail panel on render: the first leaderboard row fires hx-trigger="load, click" so users land directly on the most expensive problem without needing to click. A spinner shows while the detail fetches.

Adds Alpine-driven selected-row highlight: the active row gets a blue tint + inset ring so it's clear which session is showing in the panel. Clicking a different row transfers the highlight to the new selection.

https://claude.ai/code/session_01NZ73dcgFQr3UMMRLKUCegZ