### PR TITLE
Harness 30-day usage annotations, conversation deep-links, dashboard reorder

### DIFF
--- a/src/claudesavvy/web/routes/dashboard.py
+++ b/src/claudesavvy/web/routes/dashboard.py
@@ -92,6 +92,7 @@ def _build_preview_data(service: Any, time_filter: Optional[TimeFilter]) -> Dict
         "total_count": conv_analytics.get("summary", {}).get("total_conversations", 0),
         "most_expensive_cost": conv_analytics.get("summary", {}).get("most_expensive_cost", 0),
         "most_expensive_project": convs[0].get("project_name", "") if convs else "",
+        "most_expensive_session_id": conv_analytics.get("summary", {}).get("most_expensive_session_id", ""),
     }
 
     subagents_preview: Dict[str, Any] = service.get_subagent_summary(
@@ -442,6 +443,28 @@ def features() -> str:
         return render_template("pages/features.html", features={})
 
 
+def _annotate_feature_usage(features: Dict[str, Any], usage: Dict[str, Any]) -> None:
+    """Stamp each skill/agent/MCP config item with its 30-day call count.
+
+    Runtime names can be namespaced (e.g. 'plugin:skill'), so fall back to
+    matching on the last ':'-separated segment.
+    """
+    def _match(name: str, counter: Dict[str, int]) -> int:
+        if name in counter:
+            return counter[name]
+        short = name.split(":")[-1]
+        for used, n in counter.items():
+            if used.split(":")[-1] == short:
+                return n
+        return 0
+
+    for key in ("skills", "agents", "mcps"):
+        counter = usage.get(key, {})
+        for item in features.get(key) or []:
+            if isinstance(item, dict):
+                item["used_count"] = _match(item.get("name", ""), counter)
+
+
 def _project_scoped(features):
     """Return a copy of features containing only project-sourced items.
 
@@ -505,6 +528,29 @@ def harness() -> str:
             "commands": sum(_count(f, "commands") for f in all_features_list),
         }
 
+        # 30-day usage so the inventory shows dead weight vs. earning items
+        try:
+            usage = service.get_harness_usage(window_days=30)
+        except Exception:
+            logger.warning("Could not compute harness usage", exc_info=True)
+            usage = {"skills": {}, "agents": {}, "mcps": {}, "window_days": 30}
+        for f in all_features_list:
+            _annotate_feature_usage(f, usage)
+
+        def _used(key):
+            return sum(
+                1
+                for f in all_features_list
+                for item in (f.get(key) or [])
+                if isinstance(item, dict) and item.get("used_count")
+            )
+
+        harness_used = {
+            "skills": _used("skills"),
+            "agents": _used("agents"),
+            "mcps": _used("mcps"),
+        }
+
         default_period = "7days"
         time_filter = get_time_filter_from_period(default_period)
         evaluation = service.get_harness_evaluation(time_filter=time_filter)
@@ -517,6 +563,7 @@ def harness() -> str:
             user_features=user_features,
             project_repos=project_repos,
             harness_totals=harness_totals,
+            harness_used=harness_used,
             evaluation=evaluation,
             period=default_period,
             harness_projects=harness_projects,
@@ -531,6 +578,7 @@ def harness() -> str:
             user_features={},
             project_repos=[],
             harness_totals={"skills": 0, "agents": 0, "mcps": 0, "plugins": 0, "hooks": 0, "commands": 0},
+            harness_used={},
             evaluation=None,
             period="7days",
             harness_projects=[],

--- a/src/claudesavvy/web/routes/dashboard.py
+++ b/src/claudesavvy/web/routes/dashboard.py
@@ -453,10 +453,9 @@ def _annotate_feature_usage(features: Dict[str, Any], usage: Dict[str, Any]) -> 
         if name in counter:
             return counter[name]
         short = name.split(":")[-1]
-        for used, n in counter.items():
-            if used.split(":")[-1] == short:
-                return n
-        return 0
+        return sum(
+            n for used, n in counter.items() if used.split(":")[-1] == short
+        )
 
     for key in ("skills", "agents", "mcps"):
         counter = usage.get(key, {})

--- a/src/claudesavvy/web/services/dashboard_service.py
+++ b/src/claudesavvy/web/services/dashboard_service.py
@@ -1524,10 +1524,14 @@ class DashboardService:
             Dict with 'skills', 'agents', 'mcps' (name -> call count) and
             'window_days'.
         """
-        from datetime import date, timedelta
+        from datetime import timedelta
 
-        end = date.today()
-        start = end - timedelta(days=window_days)
+        # UTC to match the rest of the service; from_range is inclusive of
+        # both endpoints, so subtract window_days - 1 to span exactly
+        # window_days calendar days.
+        window_days = max(window_days, 1)
+        end = datetime.now(timezone.utc).date()
+        start = end - timedelta(days=window_days - 1)
         time_filter = TimeFilter.from_range(start, end)
 
         skills: Dict[str, int] = {}

--- a/src/claudesavvy/web/services/dashboard_service.py
+++ b/src/claudesavvy/web/services/dashboard_service.py
@@ -1511,6 +1511,54 @@ class DashboardService:
             else 0.0,
         }
 
+    def get_harness_usage(self, window_days: int = 30) -> Dict[str, Any]:
+        """
+        Which harness components were actually used recently.
+
+        Scans tool invocations in the last `window_days` and returns
+        invocation counters for skills (Skill tool), sub-agent types
+        (Task tool), and MCP server names — so the harness inventory can
+        show dead weight vs. components that earn their context.
+
+        Returns:
+            Dict with 'skills', 'agents', 'mcps' (name -> call count) and
+            'window_days'.
+        """
+        from datetime import date, timedelta
+
+        end = date.today()
+        start = end - timedelta(days=window_days)
+        time_filter = TimeFilter.from_range(start, end)
+
+        skills: Dict[str, int] = {}
+        agents: Dict[str, int] = {}
+        mcps: Dict[str, int] = {}
+
+        parser = self._features_analyzer.tool_parser
+        for inv in parser.parse_all(time_filter=time_filter):
+            name = inv.tool_name
+            if name == "Skill":
+                skill = ""
+                if isinstance(inv.input_params, dict):
+                    skill = str(inv.input_params.get("skill") or "")
+                if skill:
+                    skills[skill] = skills.get(skill, 0) + 1
+            elif name == "Task":
+                agent = inv.subagent_type or ""
+                if agent:
+                    agents[agent] = agents.get(agent, 0) + 1
+            elif name.startswith("mcp__"):
+                server = self._extract_mcp_server_name(name)
+                if server:
+                    mcps[server] = mcps.get(server, 0) + 1
+
+        return {
+            "skills": skills,
+            "agents": agents,
+            "mcps": mcps,
+            "window_days": window_days,
+        }
+
     def _get_session_cost_map(
         self, time_filter: Optional[TimeFilter] = None
     ) -> Dict[str, float]:
@@ -2289,6 +2337,7 @@ class DashboardService:
                 "avg_messages": round(avg_messages, 1),
                 "avg_prompts": round(avg_prompts, 1),
                 "most_expensive_session": most_expensive["session_id"][:8] if most_expensive else "",
+                "most_expensive_session_id": most_expensive["session_id"] if most_expensive else "",
                 "most_expensive_cost": most_expensive["total_cost"] if most_expensive else 0.0,
                 "most_expensive_project": most_expensive.get("project_name", "") if most_expensive else "",
                 "most_expensive_date": most_expensive.get("start_date", "") if most_expensive else "",

--- a/src/claudesavvy/web/templates/pages/conversations.html
+++ b/src/claudesavvy/web/templates/pages/conversations.html
@@ -72,5 +72,15 @@
             window.dispatchEvent(new CustomEvent('open-conv-detail'));
         }
     });
+
+    // Deep link: /conversations?session=<id> opens that conversation's detail.
+    // period=all so the lookup succeeds regardless of the page's time filter.
+    document.addEventListener('DOMContentLoaded', function() {
+        const sid = new URLSearchParams(window.location.search).get('session');
+        if (sid && /^[\w-]+$/.test(sid)) {
+            htmx.ajax('GET', '/api/conversation/' + encodeURIComponent(sid) + '?period=all',
+                      {target: '#conversation-detail-panel', swap: 'innerHTML'});
+        }
+    });
 </script>
 {% endblock %}

--- a/src/claudesavvy/web/templates/pages/harness.html
+++ b/src/claudesavvy/web/templates/pages/harness.html
@@ -214,8 +214,19 @@
                                 {% for item in items[:6] %}
                                 <li class="px-4 py-2.5 flex items-start gap-2">
                                     <span class="w-1.5 h-1.5 rounded-full mt-1.5 shrink-0" style="background: {{ color }};"></span>
-                                    <div class="min-w-0">
-                                        <div class="text-xs font-semibold text-gray-800 truncate">{{ item.name }}</div>
+                                    <div class="min-w-0 flex-1">
+                                        <div class="flex items-center gap-1.5">
+                                            <span class="text-xs font-semibold text-gray-800 truncate">{{ item.name }}</span>
+                                            {% if item.used_count is defined %}
+                                            {% if item.used_count %}
+                                            <span class="text-[10px] font-medium text-emerald-600 bg-emerald-50 px-1.5 py-0.5 rounded-full whitespace-nowrap shrink-0"
+                                                  title="Invoked {{ item.used_count }} time{{ 's' if item.used_count != 1 else '' }} in the last 30 days">{{ item.used_count }}× 30d</span>
+                                            {% else %}
+                                            <span class="text-[10px] text-gray-400 bg-gray-100 px-1.5 py-0.5 rounded-full whitespace-nowrap shrink-0"
+                                                  title="No invocations seen in the last 30 days">no use 30d</span>
+                                            {% endif %}
+                                            {% endif %}
+                                        </div>
                                         {% if item.description %}
                                         <div class="text-xs text-gray-400 truncate">{{ item.description[:80] }}{% if item.description|length > 80 %}…{% endif %}</div>
                                         {% endif %}

--- a/src/claudesavvy/web/templates/pages/harness.html
+++ b/src/claudesavvy/web/templates/pages/harness.html
@@ -50,14 +50,14 @@
     <!-- Summary KPI Row -->
     <div class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-6 gap-4">
         {% set counts = [
-            ('Skills',   harness_totals.skills,   '#2ec27e', '<path d="M12 2 14 8h6l-5 4 2 6-5-3.5L7 18l2-6-5-4h6Z"/>'),
-            ('Sub-Agents', harness_totals.agents, '#0770E3', '<circle cx="12" cy="8" r="3.5"/><path d="M5 21a7 7 0 0 1 14 0"/>'),
-            ('MCP Servers', harness_totals.mcps,  '#8b5cf6', '<path d="M4 7v10l8 4 8-4V7l-8-4-8 4Z"/><path d="m4 7 8 4 8-4"/><path d="M12 11v10"/>'),
-            ('Plugins',  harness_totals.plugins,  '#f59e0b', '<path d="M9 3v3H6a2 2 0 0 0-2 2v3h3a2 2 0 0 1 0 4H4v3a2 2 0 0 0 2 2h3v-3a2 2 0 0 1 4 0v3h3a2 2 0 0 0 2-2v-3h3a2 2 0 0 0 0-4h-3V8a2 2 0 0 0-2-2h-3V3"/>'),
-            ('Hooks',    harness_totals.hooks,    '#ef4444', '<path d="M12 4v8a4 4 0 1 1-4 4"/><circle cx="12" cy="3.5" r="1.5"/>'),
-            ('Commands', harness_totals.commands, '#6b7280', '<path d="M8 9l3 3-3 3m5 0h3M5 20h14a2 2 0 0 0 2-2V6a2 2 0 0 0-2-2H5a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2z"/>'),
+            ('Skills',   harness_totals.skills,   harness_used.get('skills'),  '#2ec27e', '<path d="M12 2 14 8h6l-5 4 2 6-5-3.5L7 18l2-6-5-4h6Z"/>'),
+            ('Sub-Agents', harness_totals.agents, harness_used.get('agents'),  '#0770E3', '<circle cx="12" cy="8" r="3.5"/><path d="M5 21a7 7 0 0 1 14 0"/>'),
+            ('MCP Servers', harness_totals.mcps,  harness_used.get('mcps'),    '#8b5cf6', '<path d="M4 7v10l8 4 8-4V7l-8-4-8 4Z"/><path d="m4 7 8 4 8-4"/><path d="M12 11v10"/>'),
+            ('Plugins',  harness_totals.plugins,  none, '#f59e0b', '<path d="M9 3v3H6a2 2 0 0 0-2 2v3h3a2 2 0 0 1 0 4H4v3a2 2 0 0 0 2 2h3v-3a2 2 0 0 1 4 0v3h3a2 2 0 0 0 2-2v-3h3a2 2 0 0 0 0-4h-3V8a2 2 0 0 0-2-2h-3V3"/>'),
+            ('Hooks',    harness_totals.hooks,    none, '#ef4444', '<path d="M12 4v8a4 4 0 1 1-4 4"/><circle cx="12" cy="3.5" r="1.5"/>'),
+            ('Commands', harness_totals.commands, none, '#6b7280', '<path d="M8 9l3 3-3 3m5 0h3M5 20h14a2 2 0 0 0 2-2V6a2 2 0 0 0-2-2H5a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2z"/>'),
         ] %}
-        {% for label, count, color, icon_path in counts %}
+        {% for label, count, used, color, icon_path in counts %}
         <div class="bg-white rounded-xl border border-gray-200 p-4 flex flex-col gap-2">
             <div class="flex items-center justify-between">
                 <span class="text-xs font-medium text-gray-500">{{ label }}</span>
@@ -66,6 +66,12 @@
                 </div>
             </div>
             <div class="text-2xl font-bold text-gray-900">{{ count }}</div>
+            {% if used is not none and count %}
+            <div class="text-[10px] {{ 'text-emerald-600' if used else 'text-gray-400' }}"
+                 title="Components with at least one invocation in the last 30 days">
+                {{ used }} of {{ count }} used in 30d
+            </div>
+            {% endif %}
         </div>
         {% endfor %}
     </div>
@@ -128,8 +134,19 @@
                             {% for item in items[:5] %}
                             <li class="px-4 py-2.5 flex items-start gap-2">
                                 <span class="w-1.5 h-1.5 rounded-full mt-1.5 shrink-0" style="background: {{ color }};"></span>
-                                <div class="min-w-0">
-                                    <div class="text-xs font-semibold text-gray-800 truncate">{{ item.name }}</div>
+                                <div class="min-w-0 flex-1">
+                                    <div class="flex items-center gap-1.5">
+                                        <span class="text-xs font-semibold text-gray-800 truncate">{{ item.name }}</span>
+                                        {% if item.used_count is defined %}
+                                        {% if item.used_count %}
+                                        <span class="text-[10px] font-medium text-emerald-600 bg-emerald-50 px-1.5 py-0.5 rounded-full whitespace-nowrap shrink-0"
+                                              title="Invoked {{ item.used_count }} time{{ 's' if item.used_count != 1 else '' }} in the last 30 days">{{ item.used_count }}× 30d</span>
+                                        {% else %}
+                                        <span class="text-[10px] text-gray-400 bg-gray-100 px-1.5 py-0.5 rounded-full whitespace-nowrap shrink-0"
+                                              title="No invocations seen in the last 30 days">no use 30d</span>
+                                        {% endif %}
+                                        {% endif %}
+                                    </div>
                                     {% if item.description %}
                                     <div class="text-xs text-gray-400 truncate">{{ item.description[:80] }}{% if item.description|length > 80 %}…{% endif %}</div>
                                     {% endif %}

--- a/src/claudesavvy/web/templates/partials/dashboard_content.html
+++ b/src/claudesavvy/web/templates/partials/dashboard_content.html
@@ -14,7 +14,7 @@
     value="$" ~ ("%.2f"|format(conversations_preview.most_expensive_cost|default(0.0)|float)),
     subtitle=conversations_preview.most_expensive_project|default("")|truncate(30, True, "…"),
     icon='<svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z"></path></svg>',
-    link="/conversations"
+    link=("/conversations?session=" ~ conversations_preview.most_expensive_session_id) if conversations_preview.most_expensive_session_id else "/conversations"
 ) }}
 
 {% set _cw_pct = ((tokens.cache_creation_cost|default(0.0)|float / tokens.total_cost|float * 100) | round(0) | int) if tokens.total_cost|default(0.0)|float > 0 else 0 %}
@@ -78,7 +78,7 @@
             {% set ctx_blocks = (ctx_pct / 10) | round(0, 'floor') | int %}
             <tr class="hover:bg-gray-50 transition-colors">
                 <td class="px-6 py-3 text-sm font-medium truncate max-w-[160px]" title="{{ conv.project_name }}">
-                    <a href="/conversations" class="text-gray-900 hover:text-[#0770E3] focus:outline-none focus:underline">{{ conv.project_name }}</a>
+                    <a href="/conversations?session={{ conv.session_id }}" class="text-gray-900 hover:text-[#0770E3] focus:outline-none focus:underline">{{ conv.project_name }}</a>
                 </td>
                 <td class="px-6 py-3 text-sm text-gray-500 hidden md:table-cell whitespace-nowrap">
                     {{ conv.start_date }} {{ conv.start_time_str }}
@@ -98,6 +98,47 @@
             {% endfor %}
         </tbody>
     </table>
+</div>
+{% endif %}
+
+<!-- Model Usage Card -->
+{% if models and models.models %}
+<div class="mt-8">
+    <div class="bg-white rounded-lg shadow-sm border border-gray-200 overflow-hidden">
+        <div class="px-6 py-4 border-b border-gray-200 flex justify-between items-center">
+            <h3 class="text-lg font-semibold text-gray-900">Model Usage</h3>
+            <a href="/tokens" class="text-sm text-[#0770E3] hover:underline flex items-center gap-1">
+                View details
+                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"></path></svg>
+            </a>
+        </div>
+        <div class="p-6">
+            <div class="space-y-4">
+                {% for model in models.models[:3] %}
+                <div class="flex items-center justify-between">
+                    <div class="flex-1 min-w-0">
+                        <div class="flex items-center justify-between mb-1">
+                            <span class="text-sm font-medium text-gray-900 truncate">{{ model.model_name }}</span>
+                            <span class="text-sm font-semibold text-[#0770E3]">{{ model.cost_percentage|default(0)|float|round(1) }}%</span>
+                        </div>
+                        <div class="w-full bg-gray-200 rounded-full h-2">
+                            <div class="bg-[#0770E3] h-2 rounded-full transition-all" style="width: {{ model.cost_percentage|default(0) }}%"></div>
+                        </div>
+                        <div class="flex justify-between mt-1">
+                            <span class="text-xs text-gray-500">{{ model.total_tokens|default(0)|format_compact }} tokens</span>
+                            <span class="text-xs text-gray-500">${{ "%.2f"|format(model.cost|default(0.0)|float) }}</span>
+                        </div>
+                    </div>
+                </div>
+                {% endfor %}
+            </div>
+            {% if models.total_models > 3 %}
+            <div class="mt-4 pt-4 border-t border-gray-200 text-center">
+                <a href="/tokens" class="text-sm text-[#0770E3] hover:underline">+{{ models.total_models - 3 }} more model{% if models.total_models - 3 > 1 %}s{% endif %} — View all</a>
+            </div>
+            {% endif %}
+        </div>
+    </div>
 </div>
 {% endif %}
 
@@ -259,43 +300,3 @@
     </div>
 </div>
 
-<!-- Model Usage Card -->
-{% if models and models.models %}
-<div class="mt-8">
-    <div class="bg-white rounded-lg shadow-sm border border-gray-200 overflow-hidden">
-        <div class="px-6 py-4 border-b border-gray-200 flex justify-between items-center">
-            <h3 class="text-lg font-semibold text-gray-900">Model Usage</h3>
-            <a href="/tokens" class="text-sm text-[#0770E3] hover:underline flex items-center gap-1">
-                View details
-                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"></path></svg>
-            </a>
-        </div>
-        <div class="p-6">
-            <div class="space-y-4">
-                {% for model in models.models[:3] %}
-                <div class="flex items-center justify-between">
-                    <div class="flex-1 min-w-0">
-                        <div class="flex items-center justify-between mb-1">
-                            <span class="text-sm font-medium text-gray-900 truncate">{{ model.model_name }}</span>
-                            <span class="text-sm font-semibold text-[#0770E3]">{{ model.cost_percentage|default(0)|float|round(1) }}%</span>
-                        </div>
-                        <div class="w-full bg-gray-200 rounded-full h-2">
-                            <div class="bg-[#0770E3] h-2 rounded-full transition-all" style="width: {{ model.cost_percentage|default(0) }}%"></div>
-                        </div>
-                        <div class="flex justify-between mt-1">
-                            <span class="text-xs text-gray-500">{{ model.total_tokens|default(0)|format_compact }} tokens</span>
-                            <span class="text-xs text-gray-500">${{ "%.2f"|format(model.cost|default(0.0)|float) }}</span>
-                        </div>
-                    </div>
-                </div>
-                {% endfor %}
-            </div>
-            {% if models.total_models > 3 %}
-            <div class="mt-4 pt-4 border-t border-gray-200 text-center">
-                <a href="/tokens" class="text-sm text-[#0770E3] hover:underline">+{{ models.total_models - 3 }} more model{% if models.total_models - 3 > 1 %}s{% endif %} — View all</a>
-            </div>
-            {% endif %}
-        </div>
-    </div>
-</div>
-{% endif %}

--- a/src/claudesavvy/web/templates/partials/dashboard_content.html
+++ b/src/claudesavvy/web/templates/partials/dashboard_content.html
@@ -14,7 +14,7 @@
     value="$" ~ ("%.2f"|format(conversations_preview.most_expensive_cost|default(0.0)|float)),
     subtitle=conversations_preview.most_expensive_project|default("")|truncate(30, True, "…"),
     icon='<svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z"></path></svg>',
-    link=("/conversations?session=" ~ conversations_preview.most_expensive_session_id) if conversations_preview.most_expensive_session_id else "/conversations"
+    link=("/conversations?session=" ~ (conversations_preview.most_expensive_session_id | urlencode)) if conversations_preview.most_expensive_session_id else "/conversations"
 ) }}
 
 {% set _cw_pct = ((tokens.cache_creation_cost|default(0.0)|float / tokens.total_cost|float * 100) | round(0) | int) if tokens.total_cost|default(0.0)|float > 0 else 0 %}
@@ -78,7 +78,7 @@
             {% set ctx_blocks = (ctx_pct / 10) | round(0, 'floor') | int %}
             <tr class="hover:bg-gray-50 transition-colors">
                 <td class="px-6 py-3 text-sm font-medium truncate max-w-[160px]" title="{{ conv.project_name }}">
-                    <a href="/conversations?session={{ conv.session_id }}" class="text-gray-900 hover:text-[#0770E3] focus:outline-none focus:underline">{{ conv.project_name }}</a>
+                    <a href="/conversations?session={{ conv.session_id | urlencode }}" class="text-gray-900 hover:text-[#0770E3] focus:outline-none focus:underline">{{ conv.project_name }}</a>
                 </td>
                 <td class="px-6 py-3 text-sm text-gray-500 hidden md:table-cell whitespace-nowrap">
                     {{ conv.start_date }} {{ conv.start_time_str }}


### PR DESCRIPTION
## What changed

**Harness inventory usage annotations (the headline)**
- New `DashboardService.get_harness_usage()` scans the last 30 days of tool invocations and counts calls per skill (Skill tool), sub-agent type (Task tool), and MCP server (`mcp__*` calls).
- The harness KPI cards now show "X of Y used in 30d" for Skills / Sub-Agents / MCP Servers; inventory items get a green `N× 30d` badge or a grey `no use 30d` badge.
- Matching falls back to the last `:`-segment of namespaced names (`plugin:skill`). Plugins/hooks/commands aren't annotated — their usage isn't observable from transcripts.

**Conversation deep-links**
- `/conversations?session=<id>` auto-opens that conversation's detail modal (fetched with `period=all` so the lookup always succeeds).
- The dashboard's Top Conversation Cost card and Recent Conversations rows now link directly to the conversation they name.

**Dashboard ordering**
- Model Usage moved above the "Explore Your Usage" navigation grid — data before navigation.

## Why

Inventory counts say nothing about quality; "196 skills, 6 used in the last 30 days" (real numbers from my data) is a harness-debugging stat. The deep links close the dashboard → conversations loop that previously dropped you on an unfiltered list.

## Reviewer notes

- The usage scan is one extra pass over transcripts on `/harness` page load only (already the heaviest page); failure falls back to no annotations.
- Verified by in-process render: KPI lines `6/196 skills, 0/52 agents, 40/64 MCPs`, deep-link script fires, Model Usage precedes the nav grid. `ruff` clean, 55/55 tests pass.
- "0 of 52 sub-agents used" is genuine: runtime types (general-purpose, Explore, team-lead) are built-ins, not the configured custom agents — which is exactly the dead weight this surfaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Dashboard displays the most expensive conversation session ID for direct access to top-cost conversations
  * Harness page now shows 30-day usage metrics and badges for all skills, agents, and MCPs
  * Usage indicators highlight components used in the last 30 days
  * Conversations page supports deep-linking to specific conversations via URL query parameter

<!-- end of auto-generated comment: release notes by coderabbit.ai -->