### PR TITLE
fix: add contents:write permission and workflow_dispatch to build-binaries

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -4,6 +4,15 @@ on:
   push:
     tags:
       - 'v*'
+  workflow_dispatch:
+    inputs:
+      tag_name:
+        description: 'Tag name for the release (e.g. v3.0.0)'
+        required: true
+        type: string
+
+permissions:
+  contents: write
 
 jobs:
   build:
@@ -25,6 +34,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.inputs.tag_name || github.ref }}
 
       - name: Set up Python
         uses: actions/setup-python@v6
@@ -51,6 +62,7 @@ jobs:
       - name: Create release
         uses: softprops/action-gh-release@v2
         with:
+          tag_name: ${{ github.event.inputs.tag_name || github.ref_name }}
           files: ${{ matrix.artifact_path }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The GITHUB_TOKEN lacked write permission, causing the v3.0.0 release
creation to fail with 403. Adds workflow_dispatch trigger so the
workflow can be manually re-run for existing tags from the default branch.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_016g8ygZxYn35Zez6AGHkruB

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced the build and release workflow to support manual execution with custom tag inputs, improving flexibility in the release process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->