### PR TITLE
Fix GitHub Pages 404 — add docs/index.html root redirect

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta http-equiv="refresh" content="0; url=demo/index.html">
+    <title>ClaudeSavvy</title>
+    <style>
+        body { font-family: system-ui, sans-serif; display: flex; align-items: center;
+               justify-content: center; height: 100vh; margin: 0; background: #f9fafb; }
+        a { color: #0770E3; font-weight: 600; }
+    </style>
+</head>
+<body>
+    <p>Redirecting to <a href="demo/index.html">demo</a>&hellip;</p>
+</body>
+</html>


### PR DESCRIPTION
## Summary

- Adds `docs/index.html` which immediately redirects to `demo/index.html`
- GitHub Pages serves from `docs/` and needs a root `index.html` to avoid a 404 on the site root URL

## Root cause

The previous PR added all demo pages under `docs/demo/` but left no `docs/index.html`, so `allannapier.github.io/claudesavvy/` returned a 404.

## After merge

- `allannapier.github.io/claudesavvy/` → redirects to the demo dashboard
- `allannapier.github.io/claudesavvy/demo/` → dashboard directly

---
_Generated by [Claude Code](https://claude.ai/code/session_01YW4RU1pDdLATDJKem22cu7)_